### PR TITLE
Add habit tracker PWA under /habits

### DIFF
--- a/habits/README.md
+++ b/habits/README.md
@@ -1,0 +1,68 @@
+# Habit Tracker
+
+PWA simples para acompanhar hábitos: calendário mensal com os dias cumpridos e
+lembretes via **service worker** no horário definido por você. Sem backend — os
+dados ficam no `localStorage` do navegador e o app funciona offline.
+
+Hospedado como subpasta deste site, em `https://blog.yagoazedias.com/habits/`.
+
+## Funcionalidades
+
+- ✅ Crie vários hábitos (nome, emoji, cor e horário de lembrete)
+- 📅 Calendário mensal: clique num dia para marcar/desmarcar como cumprido
+- 🔥 Sequência (streak), total de dias e contagem do mês
+- 🔔 Lembretes agendados via service worker no horário escolhido
+- 📴 Funciona offline (assets em cache) e é instalável (PWA)
+
+## Como rodar localmente
+
+Service workers e notificações exigem **HTTPS** ou `localhost`. Abrir o arquivo
+direto (`file://`) não funciona.
+
+Pelo Jekyll do site (a partir da raiz do repositório):
+
+```bash
+bundle exec jekyll serve
+# acesse http://localhost:4000/habits/
+```
+
+Ou servindo só esta pasta:
+
+```bash
+cd habits && python3 -m http.server 8000
+# acesse http://localhost:8000
+```
+
+## Deploy
+
+O site já publica via GitHub Pages (HTTPS) ao dar merge na branch `main`. Como o
+Pages serve em HTTPS, o service worker e as notificações funcionam direto, sem
+configuração extra. Esta pasta é copiada como conteúdo estático pelo Jekyll.
+
+## Sobre as notificações — leia isto
+
+Disparar uma notificação agendada **com o app totalmente fechado** é uma
+limitação real da plataforma web:
+
+- **Chrome/Edge (principalmente Android), com o app instalado:** usa a
+  [Notification Triggers API](https://developer.chrome.com/docs/capabilities/web-apis/notification-triggers)
+  (`TimestampTrigger`), que agenda a notificação no dispositivo e dispara mesmo
+  com o navegador fechado.
+- **Demais navegadores (Firefox, Safari):** não há `TimestampTrigger`. O app cai
+  num fallback com `setTimeout`, que **só dispara enquanto a aba/app está aberta**.
+
+Para lembretes 100% confiáveis com o app fechado em qualquer dispositivo, seria
+necessário **Web Push** (servidor com chaves VAPID + agendador) — fora do escopo
+desta versão sem backend.
+
+## Estrutura
+
+```
+habits/
+  index.html              # UI
+  manifest.webmanifest    # PWA
+  sw.js                   # service worker (cache + notificationclick)
+  css/style.css
+  js/app.js               # estado, calendário e agendamento de lembretes
+  icons/icon.svg
+```

--- a/habits/css/style.css
+++ b/habits/css/style.css
@@ -1,0 +1,240 @@
+:root {
+  --bg: #0f172a;
+  --bg-soft: #1e293b;
+  --bg-softer: #334155;
+  --text: #e2e8f0;
+  --text-dim: #94a3b8;
+  --accent: #6366f1;
+  --accent-soft: #4f46e5;
+  --danger: #ef4444;
+  --ok: #22c55e;
+  --border: #334155;
+  --radius: 12px;
+  --shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  line-height: 1.5;
+}
+
+.container {
+  width: 100%;
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 0 16px;
+}
+
+/* Topbar */
+.topbar {
+  background: var(--bg-soft);
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+.topbar__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 60px;
+}
+.brand { font-size: 1.2rem; }
+.brand strong { color: var(--accent); }
+
+/* Layout */
+.layout {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: 20px;
+  margin-top: 24px;
+  align-items: start;
+}
+@media (max-width: 720px) {
+  .layout { grid-template-columns: 1fr; }
+}
+
+/* Sidebar */
+.sidebar {
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 16px;
+}
+.sidebar__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+.sidebar__head h2 { font-size: 1rem; margin: 0; }
+.habit-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 8px; }
+.habit-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: var(--bg-softer);
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: border-color 0.15s, transform 0.1s;
+}
+.habit-item:hover { transform: translateX(2px); }
+.habit-item.is-active { border-color: var(--accent); }
+.habit-item__dot {
+  width: 12px; height: 12px; border-radius: 50%;
+  flex: 0 0 auto;
+}
+.habit-item__emoji { font-size: 1.1rem; }
+.habit-item__name {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.habit-item__badge {
+  font-size: 0.75rem;
+  color: var(--text-dim);
+  background: rgba(0,0,0,0.25);
+  padding: 2px 6px;
+  border-radius: 6px;
+}
+.empty { color: var(--text-dim); text-align: center; padding: 16px 0; font-size: 0.9rem; }
+
+/* Panel */
+.panel {
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 20px;
+  box-shadow: var(--shadow);
+}
+.panel--placeholder { display: flex; align-items: center; justify-content: center; min-height: 220px; color: var(--text-dim); }
+.panel__head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 18px;
+}
+.panel__title { margin: 0; font-size: 1.3rem; display: flex; align-items: center; gap: 8px; }
+.panel__stats { margin: 4px 0 0; color: var(--text-dim); font-size: 0.9rem; }
+.panel__actions { display: flex; gap: 8px; }
+.panel__hint { color: var(--text-dim); font-size: 0.85rem; text-align: center; margin: 14px 0 0; }
+
+/* Calendar */
+.cal__nav {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  margin-bottom: 12px;
+}
+.cal__month { font-weight: 600; min-width: 160px; text-align: center; text-transform: capitalize; }
+.cal__weekdays, .cal__grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 6px;
+}
+.cal__weekdays { margin-bottom: 6px; }
+.cal__weekday { text-align: center; font-size: 0.75rem; color: var(--text-dim); text-transform: uppercase; }
+.cal__day {
+  aspect-ratio: 1 / 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 10px;
+  background: var(--bg-softer);
+  border: 1px solid transparent;
+  cursor: pointer;
+  font-size: 0.95rem;
+  position: relative;
+  transition: transform 0.08s, background 0.15s;
+  user-select: none;
+}
+.cal__day:hover { transform: scale(1.06); }
+.cal__day.is-empty { background: transparent; cursor: default; }
+.cal__day.is-empty:hover { transform: none; }
+.cal__day.is-future { opacity: 0.4; cursor: not-allowed; }
+.cal__day.is-future:hover { transform: none; }
+.cal__day.is-today { border-color: var(--text-dim); font-weight: 700; }
+.cal__day.is-done { color: #fff; font-weight: 700; }
+.cal__day.is-done::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 10px;
+  background: var(--habit-color, var(--accent));
+  z-index: -1;
+}
+.cal__day span { position: relative; z-index: 1; }
+
+/* Buttons */
+.btn {
+  font: inherit;
+  border: 1px solid transparent;
+  border-radius: 9px;
+  padding: 8px 14px;
+  cursor: pointer;
+  color: var(--text);
+  background: var(--bg-softer);
+  transition: background 0.15s, opacity 0.15s;
+}
+.btn:hover { opacity: 0.9; }
+.btn--primary { background: var(--accent); color: #fff; }
+.btn--primary:hover { background: var(--accent-soft); }
+.btn--ghost { background: transparent; border-color: var(--border); }
+.btn--danger { background: transparent; border-color: var(--danger); color: var(--danger); }
+.btn--danger:hover { background: var(--danger); color: #fff; }
+.btn--sm { padding: 6px 10px; font-size: 0.85rem; }
+.btn--icon { padding: 4px 12px; font-size: 1.3rem; line-height: 1; }
+
+/* Banner */
+.banner {
+  margin-top: 16px;
+  padding: 12px 16px;
+  border-radius: 10px;
+  font-size: 0.9rem;
+  border: 1px solid var(--border);
+}
+.banner--warn { background: rgba(234, 179, 8, 0.12); border-color: #ca8a04; }
+.banner--ok { background: rgba(34, 197, 94, 0.12); border-color: var(--ok); }
+.banner--err { background: rgba(239, 68, 68, 0.12); border-color: var(--danger); }
+
+/* Dialog */
+.dialog {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-soft);
+  color: var(--text);
+  padding: 0;
+  max-width: 380px;
+  width: 90%;
+  box-shadow: var(--shadow);
+}
+.dialog::backdrop { background: rgba(0,0,0,0.6); }
+.dialog__form { padding: 20px; display: grid; gap: 14px; }
+.dialog__form h3 { margin: 0; }
+.field { display: grid; gap: 6px; font-size: 0.9rem; }
+.field span { color: var(--text-dim); }
+.field input {
+  font: inherit;
+  padding: 9px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--text);
+}
+.field input[type="color"] { padding: 4px; height: 42px; }
+.dialog__actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 4px; }
+
+/* Footer */
+.footer { margin: 32px auto; text-align: center; color: var(--text-dim); }

--- a/habits/icons/icon.svg
+++ b/habits/icons/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <rect width="512" height="512" rx="112" fill="#6366f1"/>
+  <path d="M150 268l68 68 144-156" fill="none" stroke="#ffffff" stroke-width="44"
+        stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/habits/index.html
+++ b/habits/index.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+  <meta name="description" content="Habit Tracker: acompanhe seus hábitos num calendário e receba lembretes no horário que você definir." />
+  <meta name="theme-color" content="#6366f1" />
+  <link rel="manifest" href="manifest.webmanifest" />
+  <link rel="icon" href="icons/icon.svg" type="image/svg+xml" />
+  <link rel="apple-touch-icon" href="icons/icon.svg" />
+  <link rel="stylesheet" href="css/style.css" />
+  <title>Habit Tracker</title>
+</head>
+<body>
+  <header class="topbar">
+    <div class="container topbar__inner">
+      <span class="brand">✅ <strong>Habit</strong> Tracker</span>
+      <button id="notif-btn" class="btn btn--ghost" type="button" title="Ativar notificações">
+        🔔 Lembretes
+      </button>
+    </div>
+  </header>
+
+  <main class="container" id="app">
+    <!-- Banner de status de notificações -->
+    <div id="notif-banner" class="banner" hidden></div>
+
+    <!-- Lista de hábitos / barra lateral -->
+    <section class="layout">
+      <aside class="sidebar">
+        <div class="sidebar__head">
+          <h2>Meus hábitos</h2>
+          <button id="add-habit-btn" class="btn btn--primary btn--sm" type="button">+ Novo</button>
+        </div>
+        <ul id="habit-list" class="habit-list"></ul>
+        <p id="empty-state" class="empty" hidden>
+          Nenhum hábito ainda.<br />Crie o primeiro para começar a marcar seus dias. 🌱
+        </p>
+      </aside>
+
+      <!-- Painel principal: calendário do hábito selecionado -->
+      <section class="panel" id="panel" hidden>
+        <div class="panel__head">
+          <div>
+            <h2 id="panel-title" class="panel__title"></h2>
+            <p id="panel-stats" class="panel__stats"></p>
+          </div>
+          <div class="panel__actions">
+            <button id="edit-habit-btn" class="btn btn--ghost btn--sm" type="button">✏️ Editar</button>
+            <button id="delete-habit-btn" class="btn btn--danger btn--sm" type="button">🗑️ Excluir</button>
+          </div>
+        </div>
+
+        <div class="cal">
+          <div class="cal__nav">
+            <button id="cal-prev" class="btn btn--ghost btn--icon" type="button" aria-label="Mês anterior">‹</button>
+            <span id="cal-month" class="cal__month"></span>
+            <button id="cal-next" class="btn btn--ghost btn--icon" type="button" aria-label="Próximo mês">›</button>
+          </div>
+          <div class="cal__weekdays" id="cal-weekdays"></div>
+          <div class="cal__grid" id="cal-grid"></div>
+        </div>
+
+        <p class="panel__hint">Clique em um dia para marcar/desmarcar o hábito como cumprido.</p>
+      </section>
+
+      <section class="panel panel--placeholder" id="placeholder">
+        <p>👈 Selecione um hábito ou crie um novo para ver o calendário.</p>
+      </section>
+    </section>
+  </main>
+
+  <!-- Modal de criar/editar hábito -->
+  <dialog id="habit-dialog" class="dialog">
+    <form method="dialog" id="habit-form" class="dialog__form">
+      <h3 id="dialog-title">Novo hábito</h3>
+
+      <label class="field">
+        <span>Nome</span>
+        <input id="f-name" name="name" type="text" maxlength="40" required placeholder="Ex.: Beber 2L de água" />
+      </label>
+
+      <label class="field">
+        <span>Emoji</span>
+        <input id="f-emoji" name="emoji" type="text" maxlength="2" placeholder="💧" />
+      </label>
+
+      <label class="field">
+        <span>Cor</span>
+        <input id="f-color" name="color" type="color" value="#6366f1" />
+      </label>
+
+      <label class="field">
+        <span>Horário do lembrete (opcional)</span>
+        <input id="f-time" name="time" type="time" />
+      </label>
+
+      <div class="dialog__actions">
+        <button type="button" id="dialog-cancel" class="btn btn--ghost">Cancelar</button>
+        <button type="submit" class="btn btn--primary">Salvar</button>
+      </div>
+    </form>
+  </dialog>
+
+  <footer class="footer container">
+    <small>Dados salvos apenas neste navegador (localStorage). Funciona offline.</small>
+  </footer>
+
+  <script src="js/app.js"></script>
+</body>
+</html>

--- a/habits/js/app.js
+++ b/habits/js/app.js
@@ -1,0 +1,456 @@
+/* Habit Tracker — lógica principal (vanilla JS, sem build) */
+(() => {
+  "use strict";
+
+  const STORAGE_KEY = "habit-tracker:v1";
+  const WEEKDAYS = ["Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sáb"];
+
+  // ---------- Estado ----------
+  let state = load();
+  let selectedId = state.habits[0]?.id ?? null;
+  let viewDate = startOfMonth(new Date()); // mês exibido no calendário
+  let swReg = null;
+  const fallbackTimers = new Map(); // habitId -> timeoutId (modo sem TimestampTrigger)
+
+  // ---------- Persistência ----------
+  function load() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (raw) return JSON.parse(raw);
+    } catch (_) {}
+    return { habits: [] };
+  }
+  function save() {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  }
+
+  // ---------- Helpers de data ----------
+  function dateKey(d) {
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, "0");
+    const day = String(d.getDate()).padStart(2, "0");
+    return `${y}-${m}-${day}`;
+  }
+  function startOfMonth(d) {
+    return new Date(d.getFullYear(), d.getMonth(), 1);
+  }
+  function todayKey() {
+    return dateKey(new Date());
+  }
+
+  // ---------- Modelo ----------
+  function getHabit(id) {
+    return state.habits.find((h) => h.id === id) || null;
+  }
+  function createHabit({ name, emoji, color, time }) {
+    const habit = {
+      id: crypto.randomUUID(),
+      name: name.trim(),
+      emoji: (emoji || "").trim() || "✅",
+      color: color || "#6366f1",
+      time: time || "",
+      createdAt: Date.now(),
+      completions: {},
+    };
+    state.habits.push(habit);
+    save();
+    return habit;
+  }
+  function updateHabit(id, patch) {
+    const h = getHabit(id);
+    if (!h) return;
+    Object.assign(h, patch);
+    save();
+  }
+  function deleteHabit(id) {
+    state.habits = state.habits.filter((h) => h.id !== id);
+    save();
+  }
+  function toggleCompletion(habit, key) {
+    if (habit.completions[key]) delete habit.completions[key];
+    else habit.completions[key] = true;
+    save();
+  }
+
+  // ---------- Estatísticas ----------
+  function totalDone(habit) {
+    return Object.keys(habit.completions).length;
+  }
+  function currentStreak(habit) {
+    let streak = 0;
+    const d = new Date();
+    // Se hoje ainda não foi feito, a sequência conta a partir de ontem.
+    if (!habit.completions[dateKey(d)]) d.setDate(d.getDate() - 1);
+    while (habit.completions[dateKey(d)]) {
+      streak++;
+      d.setDate(d.getDate() - 1);
+    }
+    return streak;
+  }
+  function doneThisMonth(habit, ref) {
+    const prefix = `${ref.getFullYear()}-${String(ref.getMonth() + 1).padStart(2, "0")}-`;
+    return Object.keys(habit.completions).filter((k) => k.startsWith(prefix)).length;
+  }
+
+  // ---------- Elementos ----------
+  const els = {
+    list: document.getElementById("habit-list"),
+    empty: document.getElementById("empty-state"),
+    panel: document.getElementById("panel"),
+    placeholder: document.getElementById("placeholder"),
+    title: document.getElementById("panel-title"),
+    stats: document.getElementById("panel-stats"),
+    calMonth: document.getElementById("cal-month"),
+    calWeekdays: document.getElementById("cal-weekdays"),
+    calGrid: document.getElementById("cal-grid"),
+    addBtn: document.getElementById("add-habit-btn"),
+    editBtn: document.getElementById("edit-habit-btn"),
+    deleteBtn: document.getElementById("delete-habit-btn"),
+    prevBtn: document.getElementById("cal-prev"),
+    nextBtn: document.getElementById("cal-next"),
+    dialog: document.getElementById("habit-dialog"),
+    form: document.getElementById("habit-form"),
+    dialogTitle: document.getElementById("dialog-title"),
+    fName: document.getElementById("f-name"),
+    fEmoji: document.getElementById("f-emoji"),
+    fColor: document.getElementById("f-color"),
+    fTime: document.getElementById("f-time"),
+    dialogCancel: document.getElementById("dialog-cancel"),
+    notifBtn: document.getElementById("notif-btn"),
+    notifBanner: document.getElementById("notif-banner"),
+  };
+
+  let editingId = null; // null = criando
+
+  // ---------- Render ----------
+  function render() {
+    renderList();
+    renderPanel();
+  }
+
+  function renderList() {
+    els.list.innerHTML = "";
+    els.empty.hidden = state.habits.length > 0;
+    for (const h of state.habits) {
+      const li = document.createElement("li");
+      li.className = "habit-item" + (h.id === selectedId ? " is-active" : "");
+      li.dataset.id = h.id;
+      const streak = currentStreak(h);
+      li.innerHTML = `
+        <span class="habit-item__dot" style="background:${h.color}"></span>
+        <span class="habit-item__emoji">${escapeHtml(h.emoji)}</span>
+        <span class="habit-item__name">${escapeHtml(h.name)}</span>
+        ${streak > 0 ? `<span class="habit-item__badge">🔥 ${streak}</span>` : ""}`;
+      li.addEventListener("click", () => {
+        selectedId = h.id;
+        viewDate = startOfMonth(new Date());
+        render();
+      });
+      els.list.appendChild(li);
+    }
+  }
+
+  function renderPanel() {
+    const habit = getHabit(selectedId);
+    const hasHabit = !!habit;
+    els.panel.hidden = !hasHabit;
+    els.placeholder.hidden = hasHabit;
+    if (!hasHabit) return;
+
+    els.title.innerHTML = `${escapeHtml(habit.emoji)} ${escapeHtml(habit.name)}`;
+    const parts = [
+      `🔥 Sequência: <strong>${currentStreak(habit)}</strong>`,
+      `📅 Este mês: <strong>${doneThisMonth(habit, viewDate)}</strong>`,
+      `✅ Total: <strong>${totalDone(habit)}</strong>`,
+    ];
+    if (habit.time) parts.push(`⏰ Lembrete: <strong>${habit.time}</strong>`);
+    els.stats.innerHTML = parts.join(" &nbsp;·&nbsp; ");
+
+    renderCalendar(habit);
+  }
+
+  function renderCalendar(habit) {
+    // Cabeçalho do mês
+    els.calMonth.textContent = viewDate.toLocaleDateString("pt-BR", {
+      month: "long",
+      year: "numeric",
+    });
+
+    // Dias da semana
+    els.calWeekdays.innerHTML = WEEKDAYS.map(
+      (w) => `<div class="cal__weekday">${w}</div>`
+    ).join("");
+
+    // Grade
+    els.calGrid.innerHTML = "";
+    els.calGrid.style.setProperty("--habit-color", habit.color);
+
+    const year = viewDate.getFullYear();
+    const month = viewDate.getMonth();
+    const firstDay = new Date(year, month, 1).getDay(); // 0=Dom
+    const daysInMonth = new Date(year, month + 1, 0).getDate();
+    const today = todayKey();
+    const todayTime = new Date(new Date().setHours(0, 0, 0, 0)).getTime();
+
+    // Células vazias antes do dia 1
+    for (let i = 0; i < firstDay; i++) {
+      const cell = document.createElement("div");
+      cell.className = "cal__day is-empty";
+      els.calGrid.appendChild(cell);
+    }
+
+    for (let day = 1; day <= daysInMonth; day++) {
+      const d = new Date(year, month, day);
+      const key = dateKey(d);
+      const cell = document.createElement("div");
+      cell.className = "cal__day";
+      if (key === today) cell.classList.add("is-today");
+      if (habit.completions[key]) cell.classList.add("is-done");
+      const isFuture = d.getTime() > todayTime;
+      if (isFuture) cell.classList.add("is-future");
+      cell.innerHTML = `<span>${day}</span>`;
+
+      if (!isFuture) {
+        cell.addEventListener("click", () => {
+          toggleCompletion(habit, key);
+          render();
+          scheduleAllReminders(); // hoje pode ter mudado → reavalia lembrete
+        });
+      }
+      els.calGrid.appendChild(cell);
+    }
+  }
+
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, (c) =>
+      ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c])
+    );
+  }
+
+  // ---------- Modal ----------
+  function openDialog(id) {
+    editingId = id ?? null;
+    const h = id ? getHabit(id) : null;
+    els.dialogTitle.textContent = h ? "Editar hábito" : "Novo hábito";
+    els.fName.value = h?.name ?? "";
+    els.fEmoji.value = h?.emoji ?? "";
+    els.fColor.value = h?.color ?? "#6366f1";
+    els.fTime.value = h?.time ?? "";
+    els.dialog.showModal();
+    els.fName.focus();
+  }
+
+  els.addBtn.addEventListener("click", () => openDialog(null));
+  els.editBtn.addEventListener("click", () => selectedId && openDialog(selectedId));
+  els.dialogCancel.addEventListener("click", () => els.dialog.close());
+
+  els.form.addEventListener("submit", (e) => {
+    e.preventDefault();
+    const data = {
+      name: els.fName.value,
+      emoji: els.fEmoji.value,
+      color: els.fColor.value,
+      time: els.fTime.value,
+    };
+    if (!data.name.trim()) return;
+    if (editingId) {
+      updateHabit(editingId, data);
+    } else {
+      const h = createHabit(data);
+      selectedId = h.id;
+    }
+    els.dialog.close();
+    render();
+    scheduleAllReminders();
+  });
+
+  els.deleteBtn.addEventListener("click", () => {
+    const h = getHabit(selectedId);
+    if (!h) return;
+    if (!confirm(`Excluir o hábito "${h.name}" e todo o histórico?`)) return;
+    deleteHabit(h.id);
+    selectedId = state.habits[0]?.id ?? null;
+    render();
+    scheduleAllReminders();
+  });
+
+  els.prevBtn.addEventListener("click", () => {
+    viewDate = new Date(viewDate.getFullYear(), viewDate.getMonth() - 1, 1);
+    renderPanel();
+  });
+  els.nextBtn.addEventListener("click", () => {
+    viewDate = new Date(viewDate.getFullYear(), viewDate.getMonth() + 1, 1);
+    renderPanel();
+  });
+
+  // ---------- Notificações / lembretes ----------
+  const supportsTriggers =
+    "Notification" in window && "showTrigger" in Notification.prototype;
+
+  function setBanner(html, kind) {
+    if (!html) {
+      els.notifBanner.hidden = true;
+      return;
+    }
+    els.notifBanner.hidden = false;
+    els.notifBanner.className = "banner banner--" + kind;
+    els.notifBanner.innerHTML = html;
+  }
+
+  function refreshNotifUI() {
+    if (!("Notification" in window)) {
+      els.notifBtn.hidden = true;
+      setBanner("Este navegador não suporta notificações.", "warn");
+      return;
+    }
+    const p = Notification.permission;
+    if (p === "granted") {
+      els.notifBtn.textContent = "🔔 Lembretes ativos";
+      const withTime = state.habits.filter((h) => h.time).length;
+      if (withTime === 0) {
+        setBanner(
+          "Notificações ativas. Defina um <strong>horário</strong> ao criar/editar um hábito para receber lembretes.",
+          "ok"
+        );
+      } else if (!supportsTriggers) {
+        setBanner(
+          "Lembretes agendados. ⚠️ Neste navegador eles só disparam enquanto o app está aberto. Para lembretes com o app fechado, use o Chrome/Edge no Android e instale o app.",
+          "warn"
+        );
+      } else {
+        setBanner(`Lembretes agendados para ${withTime} hábito(s). ⏰`, "ok");
+      }
+    } else if (p === "denied") {
+      els.notifBtn.textContent = "🔕 Bloqueado";
+      setBanner(
+        "Notificações bloqueadas. Habilite nas permissões do site para receber lembretes.",
+        "err"
+      );
+    } else {
+      els.notifBtn.textContent = "🔔 Ativar lembretes";
+      setBanner(null);
+    }
+  }
+
+  els.notifBtn.addEventListener("click", async () => {
+    if (!("Notification" in window)) return;
+    if (Notification.permission === "default") {
+      const res = await Notification.requestPermission();
+      if (res === "granted") await scheduleAllReminders();
+    }
+    refreshNotifUI();
+  });
+
+  // Calcula o próximo timestamp (ms) para "HH:MM", pulando hoje se já passou
+  // ou se o hábito já foi cumprido hoje.
+  function nextOccurrence(habit) {
+    if (!habit.time) return null;
+    const [hh, mm] = habit.time.split(":").map(Number);
+    const now = new Date();
+    const target = new Date();
+    target.setHours(hh, mm, 0, 0);
+    const doneToday = !!habit.completions[todayKey()];
+    if (target.getTime() <= now.getTime() || doneToday) {
+      target.setDate(target.getDate() + 1);
+    }
+    return target.getTime();
+  }
+
+  function reminderPayload(habit) {
+    return {
+      title: `${habit.emoji} ${habit.name}`,
+      options: {
+        body: "Hora de cumprir seu hábito de hoje! 💪",
+        tag: "reminder-" + habit.id,
+        icon: "icons/icon.svg",
+        badge: "icons/icon.svg",
+        renotify: true,
+        data: { url: "./", habitId: habit.id },
+      },
+    };
+  }
+
+  async function scheduleAllReminders() {
+    if (!("Notification" in window) || Notification.permission !== "granted") {
+      refreshNotifUI();
+      return;
+    }
+    if (!swReg) {
+      try {
+        swReg = await navigator.serviceWorker.ready;
+      } catch (_) {
+        return;
+      }
+    }
+
+    // Limpa agendamentos anteriores (ambos os modos)
+    for (const t of fallbackTimers.values()) clearTimeout(t);
+    fallbackTimers.clear();
+    if (supportsTriggers) {
+      const pending = await swReg.getNotifications({ includeTriggered: true });
+      for (const n of pending) {
+        if (n.tag && n.tag.startsWith("reminder-")) n.close();
+      }
+    }
+
+    for (const habit of state.habits) {
+      const when = nextOccurrence(habit);
+      if (!when) continue;
+      const { title, options } = reminderPayload(habit);
+
+      if (supportsTriggers) {
+        try {
+          await swReg.showNotification(title, {
+            ...options,
+            showTrigger: new TimestampTrigger(when),
+          });
+          continue;
+        } catch (_) {
+          // cai no fallback abaixo
+        }
+      }
+
+      // Fallback: setTimeout (só funciona com o app aberto)
+      scheduleFallback(habit, when);
+    }
+    refreshNotifUI();
+  }
+
+  function scheduleFallback(habit, when) {
+    const delay = when - Date.now();
+    // setTimeout estoura acima de ~24.8 dias; aqui sempre < 24h, então ok.
+    const id = setTimeout(async () => {
+      // Reavalia: pode ter sido cumprido entre o agendamento e agora.
+      if (!habit.completions[todayKey()]) {
+        const { title, options } = reminderPayload(habit);
+        try {
+          (swReg || (await navigator.serviceWorker.ready)).showNotification(
+            title,
+            options
+          );
+        } catch (_) {}
+      }
+      // Reagenda para o próximo dia.
+      const next = nextOccurrence(habit);
+      if (next) scheduleFallback(habit, next);
+    }, Math.max(0, delay));
+    fallbackTimers.set(habit.id, id);
+  }
+
+  // ---------- Service worker ----------
+  if ("serviceWorker" in navigator) {
+    window.addEventListener("load", async () => {
+      try {
+        swReg = await navigator.serviceWorker.register("sw.js");
+        await navigator.serviceWorker.ready;
+        await scheduleAllReminders();
+      } catch (err) {
+        console.warn("SW falhou:", err);
+      }
+    });
+  }
+
+  // ---------- Init ----------
+  render();
+  refreshNotifUI();
+})();

--- a/habits/manifest.webmanifest
+++ b/habits/manifest.webmanifest
@@ -1,0 +1,20 @@
+{
+  "name": "Habit Tracker",
+  "short_name": "Habits",
+  "description": "Acompanhe seus hábitos num calendário e receba lembretes no horário definido.",
+  "lang": "pt-BR",
+  "start_url": "./",
+  "scope": "./",
+  "display": "standalone",
+  "orientation": "portrait",
+  "background_color": "#0f172a",
+  "theme_color": "#6366f1",
+  "icons": [
+    {
+      "src": "icons/icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/habits/sw.js
+++ b/habits/sw.js
@@ -1,0 +1,51 @@
+/* Service Worker — cache offline + clique em notificação */
+const CACHE = "habit-tracker-v1";
+const ASSETS = [
+  "./",
+  "./index.html",
+  "./css/style.css",
+  "./js/app.js",
+  "./manifest.webmanifest",
+  "./icons/icon.svg",
+];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches.open(CACHE).then((cache) => cache.addAll(ASSETS))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(keys.filter((k) => k !== CACHE).map((k) => caches.delete(k)))
+    )
+  );
+  self.clients.claim();
+});
+
+// Cache-first para os assets locais; rede como fallback.
+self.addEventListener("fetch", (event) => {
+  const req = event.request;
+  if (req.method !== "GET") return;
+  event.respondWith(
+    caches.match(req).then((cached) => cached || fetch(req))
+  );
+});
+
+// Clique na notificação: foca uma aba existente ou abre o app.
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  const url = (event.notification.data && event.notification.data.url) || "./";
+  event.waitUntil(
+    self.clients
+      .matchAll({ type: "window", includeUncontrolled: true })
+      .then((clients) => {
+        for (const client of clients) {
+          if ("focus" in client) return client.focus();
+        }
+        if (self.clients.openWindow) return self.clients.openWindow(url);
+      })
+  );
+});


### PR DESCRIPTION
## Habit Tracker (PWA)

Adiciona um rastreador de hábitos como subpasta estática `habits/`, seguindo o mesmo padrão do `simulado-detran-rj`. Ficará acessível em `https://blog.yagoazedias.com/habits/` após o merge.

### Funcionalidades
- ✅ Múltiplos hábitos (nome, emoji, cor e horário de lembrete), salvos no `localStorage`
- 📅 Calendário mensal: clique no dia para marcar/desmarcar; datas futuras bloqueadas
- 🔥 Sequência (streak), total de dias cumpridos e contagem do mês
- 🔔 Lembretes via service worker no horário definido (`TimestampTrigger` no Chrome/Edge; fallback `setTimeout` nos demais navegadores)
- 📴 Funciona offline (cache no service worker) e é instalável (PWA)

### Stack
HTML/CSS/JS puro, sem backend e sem build. Tema escuro com acento índigo.

### Arquivos
```
habits/index.html            UI
habits/css/style.css         estilos
habits/js/app.js             estado, calendário e agendamento de lembretes
habits/sw.js                 service worker (cache + notificationclick)
habits/manifest.webmanifest  PWA
habits/icons/icon.svg
habits/README.md
```

### Notas
- Sintaxe de JS/JSON validada localmente. O build do Jekyll não foi executado no ambiente (sem Ruby/bundle), mas os arquivos são HTML estático sem front matter — idêntico ao precedente do `simulado-detran-rj`, copiado verbatim pelo Jekyll.
- Notificações com o app totalmente fechado dependem do `TimestampTrigger` (Chromium); para cobertura universal seria necessário Web Push com servidor/VAPID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VTeFPhgThVNMVhrjFSffAU)_